### PR TITLE
Bug fix

### DIFF
--- a/bark_hubert_quantizer/pre_kmeans_hubert.py
+++ b/bark_hubert_quantizer/pre_kmeans_hubert.py
@@ -57,7 +57,7 @@ class CustomHubert(nn.Module):
 
         assert model_path.exists(), f'path {checkpoint_path} does not exist'
 
-        checkpoint = torch.load(checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, map_location=device)
         load_model_input = {checkpoint_path: checkpoint}
         model, *_ = fairseq.checkpoint_utils.load_model_ensemble_and_task(load_model_input)
 


### PR DESCRIPTION
if the user doesn't have CUDA, calling the torch.load method will throw an exception:
_RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU._
Added device forwarding to map_location argument.